### PR TITLE
Actions for 'Adding the @Retry annotation' page

### DIFF
--- a/css/transHistory.css
+++ b/css/transHistory.css
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2018 IBM Corporation and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     IBM Corporation - initial API and implementation
+ *******************************************************************************/
+table.transaction {
+    border-collapse: collapse;
+    border: none;
+    table-layout: auto;
+    margin-left: 14px;
+    margin-right: 14px;
+    width: 96%;
+}
+
+table.transaction th {
+    font-weight: 300;
+    color:#8c9ba5;
+    letter-spacing:0.3px;
+    line-height:26px;
+    text-align:left;
+    font-size: 12px;
+}
+
+table.transaction .tableText {
+    padding-left: 6px;
+}
+
+table.transaction tbody tr:nth-child(even) {
+    font-size:12px;
+    background:#f0f3f6;
+    color: #152935;
+    height: 20px;
+    letter-spacing:0.46px;
+}
+
+table.transaction tbody tr:nth-child(odd) {
+    font-size:14px;
+    color: #272727;
+    height: 30px;
+    letter-spacing: 0;
+    border-bottom: 1px solid #dfe3e6;
+}
+
+table.transaction td.bl, table.transaction th.bl {
+    border-left: 1px solid #dfe3e6;
+}
+
+table.transaction td:first-child {
+    border-left: none;
+}
+
+table.transaction td:last-child {
+    border-right: none;
+}
+
+table.transaction .greenColor {
+    color: #00b4a0;
+}

--- a/html/transaction-history-retry-onRetry.html
+++ b/html/transaction-history-retry-onRetry.html
@@ -14,17 +14,37 @@
     <link href="https://fonts.googleapis.com/css?family=Asap" rel="stylesheet">
     <link rel="stylesheet" href="/guides/iguides-common/css/interactive-guides/bankApp.css">
     <link rel="stylesheet" href="/guides/draft-iguide-retry-timeout/css/transHistory.css">
+
+    <style>
+        html, body {
+            height: 100%;
+        }
+
+        #transHistory {
+            display: none;
+            overflow: auto;
+        }
+    </style>
+    <script type="text/javascript">       
+        function timeout() {
+            setTimeout(
+                function displaySystemDown() {
+                    document.getElementById("loader").style.display = "none";
+                    document.getElementById("transHistory").style.display = "block";
+                }, 2000);
+        }
+    </script>
 </head>
 <body>    
     <div class="bankHeadingBlock">
         <div class="bankHeading">Global eBank</div>
     </div>
-    
     <div class="stepIntro">
         <div class="stepIntroText">Your Account</div>
     </div>
-
-    <div>
+    
+    <div id="loader" class="loader"></div>
+    <div id="transHistory">
         <div class="stepIntroText">Recent Transactions</div>
         <table class="transaction">
             <tr>
@@ -83,6 +103,9 @@
             </tr>
         </table>
     </div>
-
+   
+    <script type="text/javascript">
+        timeout();
+    </script>
 </body>
 </html>

--- a/html/transaction-history-retry-start.html
+++ b/html/transaction-history-retry-start.html
@@ -1,0 +1,28 @@
+<!--
+  Copyright (c) 2018 IBM Corporation and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Public License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/legal/epl-v10.html
+ 
+  Contributors:
+      IBM Corporation - initial API and implementation
+-->
+<!DOCTYPE html>
+<div id="retryStep" class="pod-animation-slide-from-right" tabindex="0" aria-label="Sample web browser window">
+    <div class='browserHolder'></div>
+</div>
+<script>
+    var stepName = stepContent.getCurrentStepName();
+    var stepElementId = "retryStep";
+
+    var content = {
+        enableStatusBar: false,
+        enableRefreshButton: false,
+        callback: function test(webBrowser) {retryTimeoutCallback.listenToBrowserForTransactionHistoryAfterRetry(webBrowser); }
+    };
+
+    webBrowser.create($('#' + stepElementId).find('.browserHolder'), stepName, content).done(function (newWebBrowser) {
+        contentManager.setWebBrowser(stepName, newWebBrowser, 0);
+    });
+</script>

--- a/js/retry-timeout-callback.js
+++ b/js/retry-timeout-callback.js
@@ -292,7 +292,7 @@ var retryTimeoutCallback = (function() {
         var match = false;
         try {
             var pattern = "public class BankService {\\s*" + // readonly boundary
-            "@\\s*Retry\\s*\\(\\s*retryOn\\s*=\\s*TimeoutException\\.class\\s*\\)\\s*" +
+            "@Retry\\s*\\(\\s*retryOn\\s*=\\s*TimeoutException\\.class\\s*\\)\\s*" +
             "@Timeout\\(2000\\)"; // readonly boundary
             var regExpToMatch = new RegExp(pattern, "g");
             content.match(regExpToMatch)[0];

--- a/json-guides/retry-timeout.json
+++ b/json-guides/retry-timeout.json
@@ -291,7 +291,7 @@
                 "<ul>"
             ],
             "instruction": [
-                "Update the <code>@Retry</code> annotation on lines 13-16 to include a delay of 400ms, or click<br><action title='Add @Retry with delay'>@Retry(retryOn = TimeoutException.class,\n       maxRetries=4,\n       maxDuration=10,\n       durationUnit=ChronoUnit.SECONDS,\n       delay=400, delayUnit=ChronoUnit.MILLIS)</action>.<br> This indicates there should be a delay of 400ms following each timeout failure from the View Transaction microservice before retrying another request, but no more than 4 retries should occur and retry attempts should stop after 10 seconds.<br> Then, click <action title='Run'><b>Run</b></action> on the editor menu pane."
+                "Update the <code>@Retry</code> annotation on lines 13-16 to include a delay of 200ms, or click<br><action title='Add @Retry with delay'>@Retry(retryOn = TimeoutException.class,\n       maxRetries=4,\n       maxDuration=10,\n       durationUnit=ChronoUnit.SECONDS,\n       delay=200, delayUnit=ChronoUnit.MILLIS)</action>.<br> This indicates there should be a delay of 200ms following each timeout failure from the View Transaction microservice before retrying another request, but no more than 4 retries should occur and retry attempts should stop after 10 seconds.<br> Then, click <action title='Run'><b>Run</b></action> on the editor menu pane."
             ],
             "content": [
                 {
@@ -356,7 +356,7 @@
                 "</ul>",
                 "Why would you want to add a jitter?  Suppose, for example, that multiple applications are making requests to your microservice causing it to become overloaded.  By adding a jitter to the delay time you allow the retry times of these requests to vary.  Therefore, the cluster of retry requests are spread out over time reducing the chance that the busy service continues to be overloaded."            ],
             "instruction": [
-                "Add a jitter of 100ms to the delay in the <code>@Retry</code> annotation on lines 13-17, or click<br><action title='Add @Retry with jitter'>@Retry(retryOn = TimeoutException.class,\n       maxRetries=4,\n       maxDuration=10,\n       durationUnit=ChronoUnit.SECONDS,\n       delay=400, delayUnit=ChronoUnit.MILLIS,\n       jitter=100,\n       jitterDelayUnit=chronoUnit.MILLIS)</action>.<br> The delay between retries will now be spread out between 300 and 500 milliseconds.<br> Click <action title='Run'><b>Run</b></action> on the editor menu pane."
+                "Add a jitter of 100ms to the delay in the <code>@Retry</code> annotation on lines 13-17, or click<br><action title='Add @Retry with jitter'>@Retry(retryOn = TimeoutException.class,\n       maxRetries=4,\n       maxDuration=10,\n       durationUnit=ChronoUnit.SECONDS,\n       delay=200, delayUnit=ChronoUnit.MILLIS,\n       jitter=100,\n       jitterDelayUnit=ChronoUnit.MILLIS)</action>.<br> The delay between retries will now be spread out between 100 and 300 milliseconds.<br> Click <action title='Run'><b>Run</b></action> on the editor menu pane."
             ],
             "content": [
                 {
@@ -382,7 +382,7 @@
                                 "           maxRetries=4,",
                                 "           maxDuration=10,",
                                 "           durationUnit=ChronoUnit.SECONDS,",
-                                "           delay=400, dealyUnit=ChronoUnit.MILLIS)",
+                                "           delay=200, delayUnit=ChronoUnit.MILLIS)",
                                 "    @Timeout(2000)",
                                 "    public Service showTransactions() throws Exception {",
                                 "       Service transactions = new Transactions();",
@@ -421,7 +421,7 @@
                 "</ul>"
             ],
             "instruction": [
-                "Add a condition to the <code>@Retry</code> annotation beginning on line 14 to stop all retry attempts when a <code>FileNotFoundException</code> occurs, or click<br> <action title='Add @Retry with the abortOn parameter'>@Retry(retryOn = TimeoutException.class,\n       maxRetries=4,\n       maxDuration=10,\n       durationUnit=ChronoUnit.SECONDS,\n       delay=400, delayUnit=ChronoUnit.MILLIS,\n       jitter=100,\n       jitterDelayUnit=ChronoUnit.MILLIS,\n       abortOn=FileNotFoundException.class)</action>.<br> This Retry policy will allow all timeouts from our service to be retried up to 4 times within 10 seconds of the original timeout failure, with a delay of 300 to 500 ms between retry attempts, but will halt all retry attempts and immediately return if a <code>FileNotFoundException</code> occurs.<br>Click <action title='Run'><b>Run</b></action> on the editor menu pane."
+                "Add a condition to the <code>@Retry</code> annotation beginning on line 14 to stop all retry attempts when a <code>FileNotFoundException</code> occurs, or click<br> <action title='Add @Retry with the abortOn parameter'>@Retry(retryOn = TimeoutException.class,\n       maxRetries=4,\n       maxDuration=10,\n       durationUnit=ChronoUnit.SECONDS,\n       delay=200, delayUnit=ChronoUnit.MILLIS,\n       jitter=100,\n       jitterDelayUnit=ChronoUnit.MILLIS,\n       abortOn=FileNotFoundException.class)</action>.<br> This Retry policy will allow all timeouts from our service to be retried up to 4 times within 10 seconds of the original timeout failure, with a delay of 100 to 300 ms between retry attempts, but will halt all retry attempts and immediately return if a <code>FileNotFoundException</code> occurs.<br>Click <action title='Run'><b>Run</b></action> on the editor menu pane."
             ],
             "content": [
                 {
@@ -448,9 +448,9 @@
                                 "           maxRetries=4,",
                                 "           maxDuration=10,",
                                 "           durationUnit=ChronoUnit.SECONDS,",
-                                "           delay=400, dealyUnit=ChronoUnit.MILLIS,",
+                                "           delay=200, delayUnit=ChronoUnit.MILLIS,",
                                 "           jitter=100,",
-                                "           jitterDelayUnit=ChronoUnite.MILLIS)",
+                                "           jitterDelayUnit=ChronoUnit.MILLIS)",
                                 "    @Timeout(2000)",
                                 "    public Service showTransactions() throws Exception {",
                                 "       Service transactions = new Transactions();",

--- a/json-guides/retry-timeout.json
+++ b/json-guides/retry-timeout.json
@@ -165,7 +165,8 @@
                 "After modifying the <code>server.xml</code> file to <a href='#enabling-microprofile-fault-tolerance'> include the Fault Tolerance feature</a>, we added a Timeout policy to our sample application which will cause the transaction history microservice to fail with a <code>TimeoutException</code> if the request does not complete within 2000 milliseconds.  Now, let's add a Retry policy to the code to retry the request to the transaction history microservice when a Timeout condition occurs."
             ],
             "instruction": [
-                "Add the <code>@Retry</code> annotation on line 12, before the showTransactions method, to retry the service request only when a <code>TimeoutException</code> occurs, or click<br> <action title='Add @Retry with the retryOn parameter'>@Retry(retryOn=TimeoutException.class)</action>.<br> Then, click <action title='Run'><b>Run</b></action> on the editor menu pane."
+                "Add the <code>@Retry</code> annotation on line 12, before the <code>showTransactions</code> method, to retry the service request only when a <code>TimeoutException</code> occurs, or click<br> <action title='Add @Retry with the retryOn parameter' onclick=\"retryTimeoutCallback.addRetryOnRetryButton(event, 'AddRetryOnRetry')\">@Retry(retryOn = TimeoutException.class)</action>.<br> Then, click <action title='Run' onclick=\"retryTimeoutCallback.saveButtonEditor(event, 'AddRetryOnRetry')\"><b>Run</b></action> on the editor menu pane.",
+                "With this Retry policy in place, the request to the View Transaction microservice is automatically retried if a <code>TimeoutException</code> occurs. To demonstrate, enter the following URL into the browser that follows, or click <action title='URL to retrieve transaction history' onclick=\"retryTimeoutCallback.populateURL(event, 'AddRetryOnRetry')\"><b>https://global-ebank.openliberty.io/transactions</b></action> and then press <action title='Enter' onclick=\"retryTimeoutCallback.clickTransaction(event, 'AddRetryOnRetry', 0)\"><b>Enter</b></action> to retrieve your account transaction history.  The initial request times out after 2 seconds. Then the request is automatically retried and you will see the transaction history appear."
             ],
             "content": [
                 {
@@ -205,8 +206,9 @@
                                     "to": "19"
                                 }
                             ],
-                            "editorHeight": "450px",
-                            "save": false 
+                            "editorHeight": "390px",
+                            "save": false,
+                            "callback": "(function test(editor) {retryTimeoutCallback.listenToEditorForRetryAnnotation(editor); })"
                         }    
                     ]
                 },
@@ -227,7 +229,7 @@
                 "</ul>"
             ],
             "instruction": [
-                "Update the <code>@Retry</code> annotation on line 13 to limit the number of retry attempts to 10 and the retry duration to 4 seconds, or click<br> <action title='Add @Retry with maxRetries and maxDuration'>@Retry(retryOn=TimeoutException.class,\n       maxRetries=10,\n       maxDuration=4,\n       durationUnit=ChronoUnit.SECONDS)</action>.<br>This Retry policy initiates a retry request for each <code>TimeoutException</code> that occurs, but limits retry attempts to no more than 10 retries. The operation aborts if the total duration of all retries lasts more than 4 seconds.<br> Then, click <action title='Run'><b>Run</b></action> on the editor menu pane."
+                "Update the <code>@Retry</code> annotation on line 13 to limit the number of retry attempts to 4 and the retry duration to 10 seconds, or click<br> <action title='Add @Retry with maxRetries and maxDuration'>@Retry(retryOn = TimeoutException.class,\n       maxRetries=4,\n       maxDuration=10,\n       durationUnit=ChronoUnit.SECONDS)</action>.<br>This Retry policy initiates a retry request for each <code>TimeoutException</code> that occurs, but limits retry attempts to no more than 4 retries. The operation aborts if the total duration of all retries lasts more than 10 seconds.<br> Then, click <action title='Run'><b>Run</b></action> on the editor menu pane."
             ],
             "content": [
                 {
@@ -249,7 +251,7 @@
                                 "@ApplicationScoped",
                                 "public class BankService {",
                                 "",
-                                "    @Retry(retryOn=TimeoutException.class)",
+                                "    @Retry(retryOn = TimeoutException.class)",
                                 "    @Timeout(2000)",
                                 "    public Service showTransactions() throws Exception {",
                                 "       Service transactions = new Transactions();",
@@ -289,7 +291,7 @@
                 "<ul>"
             ],
             "instruction": [
-                "Update the <code>@Retry</code> annotation on lines 13-16 to include a delay of <code>400ms</code>, or click<br><action title='Add @Retry with delay'>@Retry(retryOn=TimeoutException.class,\n       maxRetries=10,\n       maxDuration=4,\n       durationUnit=ChronoUnit.SECONDS,\n       delay=400, delayUnit=ChronoUnit.MILLIS)</action>.<br> This indicates there should be a delay of 400ms following each timeout failure from the View Transaction microservice before retrying another request, but no more than 10 retries should occur and retry attempts should stop after 4 seconds.<br> Then, click <action title='Run'><b>Run</b></action> on the editor menu pane."
+                "Update the <code>@Retry</code> annotation on lines 13-16 to include a delay of 400ms, or click<br><action title='Add @Retry with delay'>@Retry(retryOn = TimeoutException.class,\n       maxRetries=4,\n       maxDuration=10,\n       durationUnit=ChronoUnit.SECONDS,\n       delay=400, delayUnit=ChronoUnit.MILLIS)</action>.<br> This indicates there should be a delay of 400ms following each timeout failure from the View Transaction microservice before retrying another request, but no more than 4 retries should occur and retry attempts should stop after 10 seconds.<br> Then, click <action title='Run'><b>Run</b></action> on the editor menu pane."
             ],
             "content": [
                 {
@@ -311,9 +313,9 @@
                                 "@ApplicationScoped",
                                 "public class BankService {",
                                 "",
-                                "    @Retry(retryOn=TimeoutException.class,",
-                                "           maxRetries=10,",
-                                "           maxDuration=4,",
+                                "    @Retry(retryOn = TimeoutException.class,",
+                                "           maxRetries=4,",
+                                "           maxDuration=10,",
                                 "           durationUnit=ChronoUnit.SECONDS)",
                                 "    @Timeout(2000)",
                                 "    public Service showTransactions() throws Exception {",
@@ -354,7 +356,7 @@
                 "</ul>",
                 "Why would you want to add a jitter?  Suppose, for example, that multiple applications are making requests to your microservice causing it to become overloaded.  By adding a jitter to the delay time you allow the retry times of these requests to vary.  Therefore, the cluster of retry requests are spread out over time reducing the chance that the busy service continues to be overloaded."            ],
             "instruction": [
-                "Add a jitter of 100ms to the delay in the <code>@Retry</code> annotation on lines 13-17, or click<br><action title='Add @Retry with jitter'>@Retry(retryOn=TimeoutException.class,\n       maxRetries=10,\n       maxDuration=4,\n       durationUnit=ChronoUnit.SECONDS,\n       delay=400, delayUnit=ChronoUnit.MILLIS,\n       jitter=100,\n       jitterDelayUnit=chronoUnit.MILLIS)</action>.<br> The delay between retries will now be spread out between 300 and 500 milliseconds.<br> Click <action title='Run'><b>Run</b></action> on the editor menu pane."
+                "Add a jitter of 100ms to the delay in the <code>@Retry</code> annotation on lines 13-17, or click<br><action title='Add @Retry with jitter'>@Retry(retryOn = TimeoutException.class,\n       maxRetries=4,\n       maxDuration=10,\n       durationUnit=ChronoUnit.SECONDS,\n       delay=400, delayUnit=ChronoUnit.MILLIS,\n       jitter=100,\n       jitterDelayUnit=chronoUnit.MILLIS)</action>.<br> The delay between retries will now be spread out between 300 and 500 milliseconds.<br> Click <action title='Run'><b>Run</b></action> on the editor menu pane."
             ],
             "content": [
                 {
@@ -376,9 +378,9 @@
                                 "@ApplicationScoped",
                                 "public class BankService {",
                                 "",
-                                "    @Retry(retryOn=TimeoutException.class,",
-                                "           maxRetries=10,",
-                                "           maxDuration=4,",
+                                "    @Retry(retryOn = TimeoutException.class,",
+                                "           maxRetries=4,",
+                                "           maxDuration=10,",
                                 "           durationUnit=ChronoUnit.SECONDS,",
                                 "           delay=400, dealyUnit=ChronoUnit.MILLIS)",
                                 "    @Timeout(2000)",
@@ -419,7 +421,7 @@
                 "</ul>"
             ],
             "instruction": [
-                "Add a condition to the <code>@Retry</code> annotation beginning on line 14 to stop all retry attempts when a <code>FileNotFoundException</code> occurs, or click<br> <action title='Add @Retry with the abortOn parameter'>@Retry(retryOn=TimeoutException.class,\n       maxRetries=10,\n       maxDuration=4,\n       durationUnit=ChronoUnit.SECONDS,\n       delay=400, delayUnit=ChronoUnit.MILLIS,\n       jitter=100,\n       jitterDelayUnit=ChronoUnit.MILLIS,\n       abortOn=FileNotFoundException.class)</action>.<br> This Retry policy will allow all timeouts from our service to be retried up to 10 times within 4 seconds of the original timeout failure, with a delay of 300 to 500 ms between retry attempts, but will halt all retry attempts and immediately return if a <code>FileNotFoundException</code> occurs.<br>Click <action title='Run'><b>Run</b></action> on the editor menu pane."
+                "Add a condition to the <code>@Retry</code> annotation beginning on line 14 to stop all retry attempts when a <code>FileNotFoundException</code> occurs, or click<br> <action title='Add @Retry with the abortOn parameter'>@Retry(retryOn = TimeoutException.class,\n       maxRetries=4,\n       maxDuration=10,\n       durationUnit=ChronoUnit.SECONDS,\n       delay=400, delayUnit=ChronoUnit.MILLIS,\n       jitter=100,\n       jitterDelayUnit=ChronoUnit.MILLIS,\n       abortOn=FileNotFoundException.class)</action>.<br> This Retry policy will allow all timeouts from our service to be retried up to 4 times within 10 seconds of the original timeout failure, with a delay of 300 to 500 ms between retry attempts, but will halt all retry attempts and immediately return if a <code>FileNotFoundException</code> occurs.<br>Click <action title='Run'><b>Run</b></action> on the editor menu pane."
             ],
             "content": [
                 {
@@ -442,9 +444,9 @@
                                 "@ApplicationScoped",
                                 "public class BankService {",
                                 "",
-                                "    @Retry(retryOn=TimeoutException.class,",
-                                "           maxRetries=10,",
-                                "           maxDuration=4,",
+                                "    @Retry(retryOn = TimeoutException.class,",
+                                "           maxRetries=4,",
+                                "           maxDuration=10,",
                                 "           durationUnit=ChronoUnit.SECONDS,",
                                 "           delay=400, dealyUnit=ChronoUnit.MILLIS,",
                                 "           jitter=100,",


### PR DESCRIPTION
Adding the updates to the 'Adding the @Retry annotation' page to 

- Make the instruction buttons functional
- Add 2nd instruction for after the user updates the code in the file and selects 'Run'.  Initially an empty browser is slid in on the right side.  The instruction directs the user to enter the .../transactions URL and hit enter.  This will show the Transaction History.
- HTML for what appears in the browser

Took the table css from transaction-history.html and moved it to a common file, transHistory.css.