### PR TITLE
Add labels for the timeout and retry tick marks

### DIFF
--- a/css/retry-timeout.css
+++ b/css/retry-timeout.css
@@ -56,7 +56,16 @@
 
 .legendText {
     width: 100%;
-    line-height: 14px;
+    line-height: 12px;
+    font-weight: 500;
+}
+
+.legendTextTop {
+    margin-bottom: 5px;
+}
+
+.legendTextBottom {
+    margin-top: 5px;
 }
 
 .timelineContainer {
@@ -90,16 +99,31 @@
     background-image: linear-gradient(180deg, rgb(102, 153, 0) 0%, rgb(102, 153, 0) 47%, rgb(118, 177, 1) 48%, rgb(118, 177, 1) 100%);
     left: 10%;
 }
+
+.timelineLabel {
+    position: absolute;
+    font-size: 10px;
+    text-align: right;
+} 
+
+.timeoutLabel {
+    color: rgb(180,1,1);
+}
+
+.retryLabel {
+    color: rgb(85,128,0);
+}
+
 .timelineLegend {
     line-height: 14px;
     position: absolute;
     font-size: 12px;
 }
 
-.timelineLegendStart{
+.timelineLegendStart {
     left: 6%;
 }
 
 .timelineLegendEnd {
-    right: 5%;
+    left: 92%;
 }

--- a/html/transaction-history-retry-dashboard.html
+++ b/html/transaction-history-retry-dashboard.html
@@ -32,7 +32,7 @@
 
         <div class='dashboardHolder'>
             <div class="timeline">
-                <div class="legendText" data-externalizedString="TIMEOUT"></div>
+                <div class="legendText legendTextTop" data-externalizedString="TIMEOUT"></div>
                 <div class="timelineContainer">
                     <div class="tickContainer">
                     </div>
@@ -46,7 +46,7 @@
                     <div class="timelineLegend timelineLegendStart">0</div>
                     <div class="timelineLegend timelineLegendEnd">10s</div>
                 </div>    
-                <div class="legendText" data-externalizedString="RETRY"></div>
+                <div class="legendText legendTextBottom" data-externalizedString="RETRY"></div>
             </div>
         </div>
 

--- a/js/retry-timeout-callback.js
+++ b/js/retry-timeout-callback.js
@@ -243,7 +243,7 @@ var retryTimeoutCallback = (function() {
                     // in this step, the editor had to be made very tall.  To
                     // match the height with the browser created in the pod next
                     // to the editor, increase the size of the browser.
-                    $("[data-step='AddAbortOnRetry']").find('.wbContent').attr("style", "height: 518px");
+                    $("[data-step='AddAbortOnRetry']").find('.wbContent').attr("style", "height: 518px;");
                 }
                 
                 // resize the height of the tabbed editor
@@ -419,8 +419,14 @@ var retryTimeoutCallback = (function() {
         // Do the math...
         var timeoutTickPlacement = Math.round((elapsedRetryProgress/maxDurationInMS) * 1000) / 10;  // Round to 1 decimal place
         //console.log("Timeout: " + timeoutCount + " timeoutTickPlacement: " + timeoutTickPlacement);
-        $progressBar.attr("style", "width:" + timeoutTickPlacement + "%");
-        $('<div/>').attr('class','timelineTick timeoutTick').attr('style','left:calc(' + timeoutTickPlacement + '% - 5px);').appendTo(timeoutTickContainer);
+        $progressBar.attr("style", "width:" + timeoutTickPlacement + "%;");
+
+        // Determine label for the timeout tick...convert from ms to seconds and round to 1 decimal place
+        var timeoutLabel = (elapsedRetryProgress/1000).toFixed(2) + "s";
+        $('<div/>').attr('class','timelineTick timeoutTick').attr('style','left:calc(' + timeoutTickPlacement + '% - 5px);').attr('title', timeoutLabel).appendTo(timeoutTickContainer);
+        if (stepName !== 'Playground') {
+            $('<div/>', {"class": "timelineLabel timeoutLabel", text: timeoutLabel, style: 'left:calc(' + timeoutTickPlacement + '% - 29px);'}).appendTo(timeoutTickContainer);
+        }
 
         // Show the retry tick
         var retryTickSpot = elapsedRetryProgress + delayInMS;
@@ -443,18 +449,25 @@ var retryTimeoutCallback = (function() {
             if (currentPctProgress < retryTickPctPlacement) {
                 // Advance blue progress bar until we reach the place where
                 // the retry tick should go.
-                $progressBar.attr("style", "width:" + currentPctProgress + "%");
+                $progressBar.attr("style", "width:" + currentPctProgress + "%;");
             } else {
                 clearInterval(moveProgressBar);
                 currentPctProgress = retryTickPctPlacement;
                 //console.log("retry tick placed.  CurrentPctProgress: " + currentPctProgress);
 
                 // Move the blue progress bar exactly to the retry tick spot
-                $progressBar.attr("style", "width:" + retryTickPctPlacement + "%");
+                $progressBar.attr("style", "width:" + retryTickPctPlacement + "%;");
+                elapsedRetryProgress = retryTickSpot;
 
                 // Put up the retry tick at its spot...
-                $('<div/>').attr('class','timelineTick retryTick').attr('style','left:calc(' + retryTickPctPlacement + '% - 5px);').appendTo(retryTickContainer);
-                elapsedRetryProgress = retryTickSpot;
+                // Determine label for the retry tick...convert from ms to seconds and round to 1 decimal place
+                var retryLabel = (elapsedRetryProgress/1000).toFixed(2) + "s";
+                $('<div/>').attr('class','timelineTick retryTick').attr('style','left:calc(' + retryTickPctPlacement + '% - 5px);').attr('title', retryLabel).appendTo(retryTickContainer);
+                if (stepName !== 'Playground') {
+                    $('<div/>', {"class": "timelineLabel retryLabel", text: retryLabel, style: 'left:calc(' + retryTickPctPlacement + '% - 29px);'}).appendTo(retryTickContainer);
+                }
+        
+
 
                 // Advance the progress bar until the next timeout
                 setProgressBar(maxDurationInMS, delayInMS, jitterInMS, timeout, timeoutCount, timeoutsToSimulate, elapsedRetryProgress, currentPctProgress, timeoutTickContainer, retryTickContainer, $progressBar, browser);
@@ -488,9 +501,9 @@ var retryTimeoutCallback = (function() {
             // be processed it stops and shows the transaction history.
             if (timeoutCount === timeoutsToSimulate) {
                 clearInterval(moveProgressBar);
-                currentPctProgress += 1; // Advance the progress bar to simulate processing
-                if (currentPctProgress <= 100) {
-                    $progressBar.attr("style", "width:" + currentPctProgress + "%");
+                currentPctProgress += 3; // Advance the progress bar to simulate processing
+                if (currentPctProgress < 100) {
+                    $progressBar.attr("style", "width:" + currentPctProgress + "%;");
                 } else {
                     $progressBar.attr("style", "width:100%;");
                 }
@@ -503,7 +516,7 @@ var retryTimeoutCallback = (function() {
                     currentPctProgress++;
                     //console.log("extend progress to " + currentPctProgress + "%");
                     if (currentPctProgress <= 100) {
-                        $progressBar.attr("style", "width:" + currentPctProgress + "%");
+                        $progressBar.attr("style", "width:" + currentPctProgress + "%;");
                     } else {
                         // Exceeded maxDuration!
                         //console.log("maxDuration exceeded....put up error");


### PR DESCRIPTION
Added hover over labels for the tick marks.

When on any Retry step (not the playground), the labels will also appear in the timeline showing when the Timeout and Retries are occurring.

Also, updated all the places that I add the style attribute to include a semi-colon in the value, as per Annie's review on a previous PR.  It seems to work with or without the semi-colon, but I added it to be consistent.