### PR TITLE
Refresh browser with incorrect URL post error

### DIFF
--- a/html/page-not-found.html
+++ b/html/page-not-found.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<!--
+  Copyright (c) 2018 IBM Corporation and others.
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the Eclipse Public License v1.0
+  which accompanies this distribution, and is available at
+  http://www.eclipse.org/legal/epl-v10.html
+ 
+  Contributors:
+      IBM Corporation - initial API and implementation
+-->
+ <html>
+ <head>
+    <link href="https://fonts.googleapis.com/css?family=Asap" rel="stylesheet">
+    <link rel="stylesheet" href="/guides/iguides-common/css/interactive-guides/bankApp.css">
+
+    <script type="text/javascript"> 
+        var script = document.createElement('script');
+        
+        script.onload = function() {
+            var guideRootDir = "/guides/draft-iguide-retry-timeout/nls/"
+            retrieveExternalizedStrings(guideRootDir);
+        };
+        script.src = '/guides/iguides-common/js/interactive-guides/externalized-string.js';
+        document.getElementsByTagName('head')[0].appendChild(script);
+    </script>
+
+    <style>
+            p {
+                margin-left: 10px;
+                font-size: 14px;           
+            }
+    </style>    
+ </head>
+ <body>
+    <p data-externalizedString="PAGENOTFOUND"></p>
+</body>
+</html>

--- a/nls/messages.js
+++ b/nls/messages.js
@@ -26,5 +26,6 @@ var messages = {
     MONTH: "APRIL",
     PLEASE_TRY_AGAIN: "Please try again at a later time.",
     TIMEOUT: "Timeout",
-    RETRY: "Retry"
+    RETRY: "Retry",
+    PAGENOTFOUND: "404 Page not found error"
 };


### PR DESCRIPTION
If the user selects the 'Enter' button in the 2nd instructions on the Retry pages, or selects the refresh button on the sample browser window on these pages, and either nothing is there or an incorrect URL is there, the URL should **NOT** be corrected.  Rather, an error message should be posted:

 404 Page not found error

This PR adds the message and displays it when the URL is not correct.

Also, fixed problem where the Run button on the editor was refreshing the pod content after the first instruction (index = 0) was complete.  The Run button should be a no-op at this point.