### PR TITLE
CSS improvement on retry ticks at 0 or 100%

### DIFF
--- a/css/retry-timeout.css
+++ b/css/retry-timeout.css
@@ -44,6 +44,7 @@
     border-radius: 10px;
     position: relative;
     border: 1px solid black;
+    z-index: 1;
 }
 
 .progressBar div {
@@ -98,6 +99,7 @@
     border-radius: 0 0 10px 10px;
     background-image: linear-gradient(180deg, rgb(102, 153, 0) 0%, rgb(102, 153, 0) 47%, rgb(118, 177, 1) 48%, rgb(118, 177, 1) 100%);
     left: 10%;
+    margin-top: -1.5px;
 }
 
 .timelineLabel {


### PR DESCRIPTION
When the retry ticks were at or near 0 or 100% they did not flow smoothly into the timeline.  By adding a negative margin and ensuring that the progress bar was on top (z-index), the retry ticks looked better.