### PR TITLE
Remove div IDs from shared html steps

### DIFF
--- a/html/transaction-history-retry-dashboard.html
+++ b/html/transaction-history-retry-dashboard.html
@@ -28,7 +28,7 @@
     </style>
 </head>
 <body>    
-    <div id="retryBasicStep" class="pod-animation-slide-from-right" tabindex="0" aria-label="Timeout and Retry timeline and transaction history sample browser window">
+    <div class="pod-animation-slide-from-right" tabindex="0" aria-label="Timeout and Retry timeline and transaction history sample browser window">
 
         <div class='dashboardHolder' tabindex="0" aria-label="Timeout and Retry timeline">
             <div class="timeline">
@@ -56,8 +56,6 @@
 
 <script>
     var stepName = stepContent.getCurrentStepName();
-    var stepElementId = "retryBasicStep";
-    var browser;
 
     var content = {
         enableStatusBar: false,
@@ -65,6 +63,5 @@
     };
     webBrowser.create($("[data-step='" + stepName + "']").find('.browserHolder'), stepName, content).done(function(newWebBrowser){
         contentManager.setWebBrowser(stepName, newWebBrowser, 0);
-        browser = newWebBrowser;
     });
 </script>

--- a/html/transaction-history-retry-start.html
+++ b/html/transaction-history-retry-start.html
@@ -9,12 +9,11 @@
       IBM Corporation - initial API and implementation
 -->
 <!DOCTYPE html>
-<div id="retryStep" class="pod-animation-slide-from-right" tabindex="0" aria-label="Sample web browser window">
+<div class="pod-animation-slide-from-right" tabindex="0" aria-label="Sample web browser window">
     <div class='browserHolder'></div>
 </div>
 <script>
     var stepName = stepContent.getCurrentStepName();
-    var stepElementId = "retryStep";
 
     var content = {
         enableStatusBar: false,


### PR DESCRIPTION
I had assigned IDs to the divs in the html files that are used on multiple steps.  When all steps are loaded, there was then duplicate IDs in the DOM.  I am able to remove the IDs since they aren't used in the code.