### PR TITLE
Remove <code> tags unless surrounding a default value

### DIFF
--- a/json-guides/retry-timeout.json
+++ b/json-guides/retry-timeout.json
@@ -105,7 +105,8 @@
             "description": [
                 "Now that you’ve seen the page load indefinitely due to a server side problem, let's apply a Timeout policy to limit the time the request waits.",
                 "The <code>@Timeout</code> annotation specifies the time in milliseconds allowed for the request to finish. Optionally, the <code>@Timeout</code> annotation can be configured to change the default time unit from milliseconds, for example, <code>@Timeout(value=2, unit=ChronoUnit.SECONDS)</code> with the following parameters:",
-                "<ul><li><b>value</b>: The time allowed for the request to finish. The integer value must be greater than or equal to <code>0</code>. A value of <code>0</code> means that Timeout policy is not applied. If the value is not specified, the default is <code>1000</code> milliseconds.</li><li><b>unit</b>: The unit of time for the <code>value</code> parameter as described by <code>java.time.temporal.ChronoUnit</code>. The default is <code>ChronoUnit.MILLIS</code> for milliseconds.</li>The java.time.temporal.ChronoUnit</code> class defines a standard set of date period units, including <code>NANOS, MICROS, MILLIS, SECONDS, MINUTES</code>, and <code>HOURS.</code></ul>",
+                "<ul><li><b>value</b>: The time allowed for the request to finish. The integer value must be greater than or equal to 0. A value of 0 means that Timeout policy is not applied. If the value is not specified, the default is <code>1000</code> milliseconds.</li>",
+                "<li><b>unit</b>: The unit of time for the <code>value</code> parameter as described by <code>java.time.temporal.ChronoUnit</code>. The default is <code>ChronoUnit.MILLIS</code> for milliseconds.</li>The java.time.temporal.ChronoUnit</code> class defines a standard set of date period units, including <code>NANOS, MICROS, MILLIS, SECONDS, MINUTES</code>, and <code>HOURS.</code></ul>",
                 "With a Timeout policy, a <code>TimeoutException</code> occurs when the timeout value has elapsed.",
                 "After you modify your <code>server.xml</code> file to <a href='#enabling-microprofile-fault-tolerance-in-open-liberty'> include the Fault Tolerance feature</a>, add a Timeout policy to the transaction history microservice."
             ],
@@ -224,7 +225,7 @@
             "TOCIndent": 1,
             "description": [
                 "You can set limits on the number of retry attempts to prevent a busy service from becoming overloaded with retry requests which ties up resources and takes the service even longer to recover from its failing condition. The <code>@Retry</code> annotation has parameters that limit the number of retry attempts and that limit the amount of time a service can spend retrying.",
-                "<ul><li><b>maxRetries:</b> The maximum number of retry requests. The integer value must be greater than or equal to -1.  A value of <code>-1</code> indicates to continue retrying forever. The default is <code>3</code> requests.",
+                "<ul><li><b>maxRetries:</b> The maximum number of retry requests. The integer value must be greater than or equal to -1.  A value of -1 indicates to continue retrying forever. The default is <code>3</code> requests.",
                 "<li><b>maxDuration:</b> The maximum amount of time to perform all requests, including the initial request and all retry attempts. Once the duration is reached, no more retry attempts are initiated.  This integer value must be greater than or equal to 0. The default is <code>180000</code> units, as defined by the <code>durationUnit</code> parameter.",
                 "<li><b>durationUnit:</b> The unit of time for the <code>maxDuration</code> parameter as described by <code>java.time.temporal.ChronoUnit</code>. The default is <code>ChronoUnit.MILLIS</code> for milliseconds.<p style='margin-top: inherit;'>The <code>java.time.temporal.ChronoUnit</code> class defines a standard set of date period units, including <code>NANOS, MICROS, MILLIS, SECONDS, MINUTES,</code> and <code>HOURS</code>.",
                 "</ul>"
@@ -289,7 +290,7 @@
             "TOCIndent": 1,
             "description": [
                 "Sometimes an application should wait before issuing a retry request. For example, if the failure is caused by a sudden spike in requests or a loss of connectivity, waiting may decrease the chance that a previous failure occurs.  In these cases, you can define a delay in the Retry policy. ",
-                "<ul><li><b>delay:</b> The amount of time to wait before retrying a request.  The value must be an integer greater than or equal to <code>0</code> and be less than the value for <a href='#adding-retry-limits'><b>maxDuration</b></a>.  The default is <code>0</code>.",
+                "<ul><li><b>delay:</b> The amount of time to wait before retrying a request.  The value must be an integer greater than or equal to 0 and be less than the value for <a href='#adding-retry-limits'>maxDuration</a>.  The default is <code>0</code>.",
                 "<li><b>delayUnit:</b> The unit of time for the <code>delay</code> parameter as described by <code>java.time.temporal.ChronoUnit</code>.  The default is ChronoUnit.MILLIS. <p style='margin-top: inherit;'>The <code>java.time.temporal.ChronoUnit</code> class defines a standard set of date period units, including <code>NANOS, MICROS, MILLIS, SECONDS, MINUTES,</code> and <code>HOURS</code>.",
                 "<ul>"
             ],
@@ -356,7 +357,7 @@
             "TOCIndent": 1,
             "description": [
                 "The Retry policy also provides a way to add jitter to the delay.  Jitter causes a slight variation in the delay time applied between retries.  For example, a jitter of 200ms will randomly add between -200 and 200 ms to each retry delay interval.",
-                "<ul><li><b>jitter:</b> A random variation applied to the <a href='#configuring-a-delay'>delay</a> interval between retries. The integer value must be greater than or equal to <code>0</code>. A value of <code>0</code> means that it is not set. If the specified jitter value is larger than the delay value then the jitter is set to the delay value. The default is <code>200</code> units, as defined by the <code>jitterDelayUnit</code> parameter.",
+                "<ul><li><b>jitter:</b> A random variation applied to the <a href='#configuring-a-delay'>delay</a> interval between retries. The integer value must be greater than or equal to 0. A value of 0 means that it is not set. If the specified jitter value is larger than the delay value then the jitter is set to the delay value. The default is <code>200</code> units, as defined by the <code>jitterDelayUnit</code> parameter.",
                 "<li><b>jitterDelayUnit:</b> The unit of time for the <code>jitter</code> parameter as described by <code>java.time.temporal.ChronoUnit</code>.  The default is ChronoUnit.MILLIS. <p style='margin-top: inherit;'>The <code>java.time.temporal.ChronoUnit</code> class defines a standard set of date period units, including <code>NANOS, MICROS, MILLIS, SECONDS, MINUTES,</code> and <code>HOURS</code>.",
                 "</ul>",
                 "Why would you want to add a jitter?  Suppose, for example, that multiple applications are making requests to your microservice causing it to become overloaded.  By adding a jitter to the delay time you allow the retry times of these requests to vary.  Therefore, the cluster of retry requests are spread out over time reducing the chance that the busy service continues to be overloaded."            ],
@@ -495,7 +496,7 @@
                 "Now that you learned about Timeout and Retry, you can explore the parameters in the <code>@Timeout</code> and <code>@Retry</code> annotations and see how they all work together.",
                 "You can make change to the following parameters:",
                 "<code>@Timeout</code>:",
-                "<ul><li><b>value</b>: The time allowed for the request to finish. The integer value must be greater than or equal to <code>0</code>. A value of <code>0</code> means that Timeout policy is not applied. If the value is not specified, the default is <code>1000</code> milliseconds.</li>",
+                "<ul><li><b>value</b>: The time allowed for the request to finish. The integer value must be greater than or equal to 0. A value of 0 means that Timeout policy is not applied. If the value is not specified, the default is <code>1000</code> milliseconds.</li>",
                 "</ul>",
                 "<code>@Retry</code>:",
                 "<ul><li><b>maxRetries:</b> The maximum number of retry requests. The integer value must be greater than or equal to -1.  A value of -1 indicates to continue retrying forever. The default is <code>3</code> requests.",


### PR DESCRIPTION
As per group discussion, remove code tags around numbers that are just part of a sentence.   They only belong around numbers that are the default value.